### PR TITLE
Change write-csv to be symmetric with parse-csv

### DIFF
--- a/src/csv_map/core.clj
+++ b/src/csv_map/core.clj
@@ -24,7 +24,7 @@
   [csv & {key :key :as opts}]
   (let [opts   (vec (reduce concat (vec opts)))
         c      (apply clojure-csv.core/parse-csv csv opts)
-        output (map (partial zipmap (first c)) (rest c))]
+        output (map (partial zipmap (reverse (first c))) (map reverse (rest c)))]
     (if (= key :keyword) (map keywordize- output) output)))
 
 (defn write-csv
@@ -38,5 +38,5 @@
                     (vec (map (fn [item]
                            (get line item))
                          header)))
-                  (rest map-sequence))]
-    (apply clojure-csv.core/write-csv (cons header data) opts)))
+                  map-sequence)]
+    (apply clojure-csv.core/write-csv (cons (map name header) data) opts)))

--- a/test/csv_map/core_test.clj
+++ b/test/csv_map/core_test.clj
@@ -2,6 +2,20 @@
   (:use clojure.test
         csv-map.core))
 
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))
+(def test-csv
+  (str
+    "a,b,c\n"
+    "1,2,3\n"
+    "4,5,6\n"
+  )
+)
+
+(deftest write-is-symmetric
+  (testing "write-csv is symmetric with parse-csv (for simple headers)"
+    (is (= (write-csv (parse-csv test-csv)) test-csv)))
+)
+
+(deftest write-is-symmetric-for-keyword
+  (testing "write-csv is keyword-symmetric with parse-csv (for simple headers)"
+    (is (= (write-csv (parse-csv test-csv :key :keyword)) test-csv)))
+)


### PR DESCRIPTION
Doesn't work for more complicated keys (because keyword conversion is lossy) but good for simple ones

Fixes #4